### PR TITLE
rename category instances to template name

### DIFF
--- a/src/domainManagementUI/src/app/components/domain/domain-list/domain-list.component.ts
+++ b/src/domainManagementUI/src/app/components/domain/domain-list/domain-list.component.ts
@@ -86,8 +86,8 @@ export class DomainListComponent implements OnInit {
         let applicationLowerCase = domain['application_name']
           ? (domain['application_name'] as string)
           : '';
-        let templateLowerCase = domain['category']
-          ? (domain['category'] as string)
+        let templateLowerCase = domain['template_name']
+          ? (domain['template_name'] as string)
           : '';
         domain['nameLowerCase'] = nameLowerCase.toLowerCase();
         domain[

--- a/src/domainManagementUI/src/app/components/template/template-details/tabs/demo/template-details-demo.component.ts
+++ b/src/domainManagementUI/src/app/components/template/template-details/tabs/demo/template-details-demo.component.ts
@@ -61,14 +61,22 @@ export class TemplateDetailsDemoComponent implements OnInit, OnDestroy {
 
   setURL(template: TemplateModel) {
     console.log(template);
-    this.safeURL = this.domSanitizer.bypassSecurityTrustResourceUrl(
-      `https://${template.s3_url}preview/home.html`
-    );
+    if (this.tdTabSvc.template_data.is_go_template) {
+      var url = `https://${this.tdTabSvc.template_data.s3_url}preview/home.html`;
+    } else {
+      var url = `https://${this.tdTabSvc.template_data.s3_url}template/home.html`;
+    }
+    this.safeURL = this.domSanitizer.bypassSecurityTrustResourceUrl(url);
     console.log(this.safeURL);
   }
 
   openInNewTab() {
-    var url = `https://${this.tdTabSvc.template_data.s3_url}preview/home.html`;
+    if (this.tdTabSvc.template_data.is_go_template) {
+      var url = `https://${this.tdTabSvc.template_data.s3_url}preview/home.html`;
+    } else {
+      var url = `https://${this.tdTabSvc.template_data.s3_url}template/home.html`;
+    }
+
     window.open(url, '_blank');
   }
 

--- a/src/domainManagementUI/src/app/models/domain.model.ts
+++ b/src/domainManagementUI/src/app/models/domain.model.ts
@@ -9,7 +9,7 @@ export class DomainModel extends BaseModel {
   template_base_name: string;
   template_base_name_lower_case: string;
   template_base_uuid: string;
-  category: string;
+  template_name: string;
   domain_parameters: WebSiteParameter[];
   application_name: string;
   application_name_lower_case: string;

--- a/src/domainManagementUI/src/app/models/template.model.ts
+++ b/src/domainManagementUI/src/app/models/template.model.ts
@@ -8,7 +8,7 @@ export class TemplateModel extends BaseModel {
   createdByLowerCase: string;
   template_attributes: Array<TemplateAttribute>;
   selected: boolean;
-  is_go_template: boolean;
+  is_go_template = true;
 }
 
 export class TemplateAttribute {

--- a/src/domainManagementUI/src/app/models/template.model.ts
+++ b/src/domainManagementUI/src/app/models/template.model.ts
@@ -8,6 +8,7 @@ export class TemplateModel extends BaseModel {
   createdByLowerCase: string;
   template_attributes: Array<TemplateAttribute>;
   selected: boolean;
+  is_go_template: boolean;
 }
 
 export class TemplateAttribute {

--- a/src/domainManagementUI/src/app/services/domain.service.ts
+++ b/src/domainManagementUI/src/app/services/domain.service.ts
@@ -54,9 +54,9 @@ export class DomainService extends AbstractUploadService {
     return this.http.delete(url, headers);
   }
 
-  uploadDomain(formData, domainId, category) {
+  uploadDomain(formData, domainId, templateName) {
     console.log(formData);
-    let url = `${this.settingsService.settings.apiUrl}/api/domain/${domainId}/content/?category=${category}`;
+    let url = `${this.settingsService.settings.apiUrl}/api/domain/${domainId}/content/?template-name=${templateName}`;
 
     if (!environment.localData) {
       const config = new HttpRequest('POST', url, formData, {
@@ -162,7 +162,7 @@ export class DomainService extends AbstractUploadService {
   }
 
   generateFromTemplate(domain_id, template_name, attributes: {}) {
-    let url = `${this.settingsService.settings.apiUrl}/api/domain/${domain_id}/generate/?category=${template_name}`;
+    let url = `${this.settingsService.settings.apiUrl}/api/domain/${domain_id}/generate/?template-name=${template_name}`;
     console.log(url);
 
     if (!environment.localData) {

--- a/src/domainManagementUI/src/app/services/domain.service.ts
+++ b/src/domainManagementUI/src/app/services/domain.service.ts
@@ -56,7 +56,7 @@ export class DomainService extends AbstractUploadService {
 
   uploadDomain(formData, domainId, templateName) {
     console.log(formData);
-    let url = `${this.settingsService.settings.apiUrl}/api/domain/${domainId}/content/?template-name=${templateName}`;
+    let url = `${this.settingsService.settings.apiUrl}/api/domain/${domainId}/content/?template_name=${templateName}`;
 
     if (!environment.localData) {
       const config = new HttpRequest('POST', url, formData, {
@@ -162,7 +162,7 @@ export class DomainService extends AbstractUploadService {
   }
 
   generateFromTemplate(domain_id, template_name, attributes: {}) {
-    let url = `${this.settingsService.settings.apiUrl}/api/domain/${domain_id}/generate/?template-name=${template_name}`;
+    let url = `${this.settingsService.settings.apiUrl}/api/domain/${domain_id}/generate/?template_name=${template_name}`;
     console.log(url);
 
     if (!environment.localData) {

--- a/src/domainManagementUI/src/app/services/tab-services/template-details-tabs.service.ts
+++ b/src/domainManagementUI/src/app/services/tab-services/template-details-tabs.service.ts
@@ -77,7 +77,7 @@ export class TemplateDetailsTabService {
       (success) => {
         let data = success as Array<DomainModel>;
         this.domains_used_list = data.filter(
-          (ws) => ws.category === this.template_data.name
+          (ws) => ws.template_name === this.template_data.name
         );
       },
       (failure) => {


### PR DESCRIPTION
Rename all instances of "category" which was intended the template name to "template_name"

## 💭 Description
Minimize confusion and improve readability due to "category" being reserved for a different meaning

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [X] My code follows the code style of this project.
- [X] My changes have been adequately tested locally.
- [X] All automated tests are passing.
- [X] I have updated/added required automated tests.
- [X] Pre-commit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->
