### PR TITLE
feature: dm-317

### DIFF
--- a/src/domainManagementUI/src/app/components/domain/domain-details/tabs/template-selection/domain-details-template-selection.component.html
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/tabs/template-selection/domain-details-template-selection.component.html
@@ -156,7 +156,8 @@
             trim="blur"
             type="text"
             formControlName="{{ attribute.key }}"
-            placeholder=" Type Attribute Here"
+            placeholder=" {{ attribute.value }}"
+            autocomplete="off"
           />
         </mat-form-field>
       </div>

--- a/src/domainManagementUI/src/app/components/domain/domain-details/tabs/template-selection/domain-details-template-selection.component.html
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/tabs/template-selection/domain-details-template-selection.component.html
@@ -156,7 +156,7 @@
             trim="blur"
             type="text"
             formControlName="{{ attribute.key }}"
-            placeholder=" {{ attribute.value }}"
+            [(ngModel)]="attribute.value"
             autocomplete="off"
           />
         </mat-form-field>

--- a/src/domainManagementUI/src/app/services/tab-services/domain-details-tabs.service.ts
+++ b/src/domainManagementUI/src/app/services/tab-services/domain-details-tabs.service.ts
@@ -73,6 +73,7 @@ export class DomainDetailsTabService {
       this.domain_data = new DomainModel();
       this.domain_data = await this.domainSvc.getDomainDetails(_id);
       this.domain_data_behavior_subject.next(this.domain_data);
+      this._buildAttributesForm(this.domain_data.name);
     } catch (failure) {
       this.alertsSvc.alert(failure.message);
     } finally {
@@ -136,7 +137,6 @@ export class DomainDetailsTabService {
   _rebuildForms() {
     this._buildTemplateSelectionForm();
     this._buildSummaryForm();
-    this._buildAttributesForm();
     this._buildCategoryForm();
   }
 
@@ -147,15 +147,22 @@ export class DomainDetailsTabService {
     });
   }
 
-  _buildAttributesForm() {
+  _buildAttributesForm(name: string) {
     this.attributes_form = new FormGroup({});
-
     this.templateSvc
       .getTemplateAttributes()
-      .subscribe((attributes: string[]) => {
-        attributes.forEach((att: string) => {
+      .subscribe((attributes: { [key: string]: string }) => {
+        Object.entries(attributes).forEach((key, value) => {
           const attribute = new TemplateAttribute();
-          attribute.key = att;
+
+          if (key[0] == 'name') {
+            key[1] = name;
+          } else if (key[0] == 'email') {
+            key[1] = `info@${name}`;
+          }
+
+          attribute.key = key[0];
+          attribute.value = key[1];
           this.attributeList.push(attribute);
           this.attributes_form.addControl(
             attribute.key,


### PR DESCRIPTION
Use faker data for template attributes.

## 💭 Description
Add logic to autofill name and email utilizing the domain name
pull faker data from and fill remaining template attribute fields

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [X] My code follows the code style of this project.
- [X] My changes have been adequately tested locally.
- [X] All automated tests are passing.
- [X] I have updated/added required automated tests.
- [X] Pre-commit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->
