### PR TITLE
remove disabled submit button unless field is touched functionality

### DIFF
--- a/src/domainManagementUI/src/app/components/domain/domain-details/tabs/template-selection/domain-details-template-selection.component.html
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/tabs/template-selection/domain-details-template-selection.component.html
@@ -150,7 +150,7 @@
         *ngFor="let attribute of ddTabSvc.attributeList; let i; index"
       >
         <mat-form-field style="width: 20em" appearance="outline">
-          <mat-label>{{ attribute.key | titlecase }}</mat-label>
+          <mat-label>{{ attribute.key }}</mat-label>
           <input
             matInput
             trim="blur"

--- a/src/domainManagementUI/src/app/components/domain/domain-details/tabs/template-selection/domain-details-template-selection.component.html
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/tabs/template-selection/domain-details-template-selection.component.html
@@ -150,7 +150,7 @@
         *ngFor="let attribute of ddTabSvc.attributeList; let i; index"
       >
         <mat-form-field style="width: 20em" appearance="outline">
-          <mat-label>{{ attribute.key }}</mat-label>
+          <mat-label>{{ attribute.key | titlecase }}</mat-label>
           <input
             matInput
             trim="blur"
@@ -169,7 +169,6 @@
         color="primary"
         class="flex"
         (click)="generateFromTemplate()"
-        [disabled]="!attributeForm.valid"
       >
         Create Domain HTML
       </button>


### PR DESCRIPTION
Remove validation requirement for default grayed out button

## 💭 Description

The template attributes submit button remains disabled until a user has to click on a template attribute field.
Now that all fields have pre-generated data, the button no longer needs to be disabled and a user can submit right away

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [X] My code follows the code style of this project.
- [X] My changes have been adequately tested locally.
- [X] All automated tests are passing.
- [X] I have updated/added required automated tests.
- [X] Pre-commit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->
