### PR TITLE
dm-407: remove bulk upload capability from domains web content upload 

### DIFF
--- a/src/domainManagementUI/src/app/components/dialog-windows/file-upload/file-upload-dialog.component.html
+++ b/src/domainManagementUI/src/app/components/dialog-windows/file-upload/file-upload-dialog.component.html
@@ -90,7 +90,8 @@ someone has to deal with this
 
   <!-- File List -->
   <div style="margin-bottom: 40px; margin-top: 2em">
-    <h3>{{ files.length }} Queued Files</h3>
+    <h3 *ngIf="multipleFileUpload">{{ files.length }} Queued Files</h3>
+    <h3 *ngIf="!multipleFileUpload">Queued File</h3>
     <div>
       <table class="table">
         <thead>
@@ -156,7 +157,8 @@ someone has to deal with this
                 <mat-icon
                   style="font-size: 2.5em; color: red; cursor: initial"
                   [matTooltip]="item.errorMessage"
-                  >priority_high</mat-icon
+                >
+                  priority_high</mat-icon
                 >
               </div>
               <div *ngIf="item.uploadStatus == 'Canceled'">

--- a/src/domainManagementUI/src/app/components/dialog-windows/file-upload/file-upload-dialog.component.ts
+++ b/src/domainManagementUI/src/app/components/dialog-windows/file-upload/file-upload-dialog.component.ts
@@ -24,7 +24,7 @@ export class FileUploadDialogComponent implements OnInit {
   isMultipleDisplayText = 'one';
   uploadType = 'File';
   uploadFileType = '*';
-
+  allowSingleFile = false;
   uploadProcessed = false;
   filesCurrentlyUploading = 0;
 
@@ -56,6 +56,7 @@ export class FileUploadDialogComponent implements OnInit {
     dialogRef.disableClose = true;
     this.uploadFileType = this.getNativeMimeType(data.uploadFileType);
     this.multipleFileUpload = data.multipleFileUpload;
+    this.allowSingleFile = data.allowSingleFile;
   }
   ngOnInit(): void {
     this.data.uploadService.preloadValidationData();
@@ -165,9 +166,15 @@ export class FileUploadDialogComponent implements OnInit {
   }
 
   fileAdded() {
+    console.log(this.files);
+    if (this.allowSingleFile && this.files.length > 1) {
+      this.files.splice(0, 1);
+    }
+
     const invalidfiles = this.data.uploadService.validateBeforeUpload(
       this.files
     );
+
     if (invalidfiles.length > 0) {
       this.overwrite = true;
       for (const file of invalidfiles) {

--- a/src/domainManagementUI/src/app/components/domain/domain-details/tabs/template-selection/domain-details-template-selection.component.ts
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/tabs/template-selection/domain-details-template-selection.component.ts
@@ -163,6 +163,7 @@ export class DomainDetailsTemplateSelectionComponent
     fileUploadSettings.uploadType = 'domain';
     fileUploadSettings.uploadFileType = 'application/zip';
     fileUploadSettings.multipleFileUpload = false;
+    fileUploadSettings.allowSingleFile = true;
     fileUploadSettings.uploadService = this.ddTabSvc.domainSvc;
     fileUploadSettings.ID = this.ddTabSvc.domain_data._id;
     fileUploadSettings.DomainDomain = this.ddTabSvc.domain_data.name;

--- a/src/domainManagementUI/src/app/models/fileUploadSettings.model.ts
+++ b/src/domainManagementUI/src/app/models/fileUploadSettings.model.ts
@@ -3,7 +3,7 @@ import { AbstractUploadService } from '../services/abstract-upload.service';
 export class FileUploadSettings {
   uploadType: string; //Display String
   uploadFileType: string = '*'; //The html [accept] attribute example = "application/zip" or "text.html"
-
+  allowSingleFile: boolean = false;
   multipleFileUpload: boolean = true;
   uploadService: AbstractUploadService;
   ID: string;


### PR DESCRIPTION
Remove ability to upload multiple files to a domain when uploading zipped content file. 

## 💭 Description

Domains should only be able to upload one file at a time. This is already enforced in the API. This is a cosmetic bug fix to reduce confusion for users.

## ✅ Checklist

- [X] My code follows the code style of this project.
- [X] My changes have been adequately tested locally.
- [X] All automated tests are passing.
- [X] I have updated/added required automated tests.
- [X] Pre-commit checks are passing.
