### PR TITLE
remove delete button for general users

### DIFF
--- a/src/domainManagementUI/src/app/components/domain/domain-details/domain-details.component.html
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/domain-details.component.html
@@ -29,7 +29,11 @@
     >
       <mat-icon>download</mat-icon>Download ZIP
     </button>
-    <button mat-menu-item (click)="deleteDomain()">
+    <button
+      mat-menu-item
+      *ngIf="userAuthSvc.userIsAdmin()"
+      (click)="deleteDomain()"
+    >
       <mat-icon>delete</mat-icon> Delete
     </button>
   </mat-menu>

--- a/src/domainManagementUI/src/app/components/domain/domain-details/domain-details.component.ts
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/domain-details.component.ts
@@ -7,6 +7,7 @@ import { Router } from '@angular/router';
 // Local Service Imports
 import { AlertsService } from 'src/app/services/alerts.service';
 import { LayoutService } from 'src/app/services/layout.service';
+import { UserAuthService } from 'src/app/services/user-auth.service';
 import { DomainService } from 'src/app/services/domain.service';
 import { DomainDetailsTabService } from 'src/app/services/tab-services/domain-details-tabs.service';
 
@@ -37,7 +38,8 @@ export class DomainDetailsComponent implements OnInit, OnDestroy {
     public layoutSvc: LayoutService,
     private router: Router,
     public ddTabSvc: DomainDetailsTabService,
-    public domainTemplateSvc: DomainService
+    public domainTemplateSvc: DomainService,
+    public userAuthSvc: UserAuthService
   ) {
     this.layoutSvc.setTitle('Domain Details');
   }


### PR DESCRIPTION
Disable the ability to delete a domain for general users

## 💭 Description

Only allow admins to have the ability to delete domains.

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [X] My code follows the code style of this project.
- [X] My changes have been adequately tested locally.
- [X] All automated tests are passing.
- [X] I have updated/added required automated tests.
- [X] Pre-commit checks are passing.
