### PR TITLE
Token Refresh Bug Fix

### DIFF
--- a/src/domainManagementUI/src/app/services/login.service.ts
+++ b/src/domainManagementUI/src/app/services/login.service.ts
@@ -61,7 +61,11 @@ export class LoginService {
     localStorage.setItem('expires_at', authResult.expires_at);
     localStorage.setItem('username', authResult.username);
     localStorage.setItem('isAdmin', 'false');
-    this.cookieSvc.set('dm-auth-refresh-token', authResult.refresh_token, {secure: true, expires: 30, sameSite: 'Strict'});
+    this.cookieSvc.set('dm-auth-refresh-token', authResult.refresh_token, {
+      secure: true,
+      expires: 30,
+      sameSite: 'Strict',
+    });
     this.startRefreshTokenTimer();
     try {
       const jwt = jwt_decode(authResult.id_token);

--- a/src/domainManagementUI/src/app/services/login.service.ts
+++ b/src/domainManagementUI/src/app/services/login.service.ts
@@ -61,7 +61,7 @@ export class LoginService {
     localStorage.setItem('expires_at', authResult.expires_at);
     localStorage.setItem('username', authResult.username);
     localStorage.setItem('isAdmin', 'false');
-    this.cookieSvc.set('dm-auth-refresh-token', authResult.refresh_token);
+    this.cookieSvc.set('dm-auth-refresh-token', authResult.refresh_token, {secure: true, expires: 30, sameSite: 'Strict'});
     this.startRefreshTokenTimer();
     try {
       const jwt = jwt_decode(authResult.id_token);


### PR DESCRIPTION
## 💭 Description

Fix issue with the jwt refresh token stored in a cookie expiring before it should. Set expire date to that of the cognito refresh token expiration date.

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [x] My code follows the code style of this project.
- [x] My changes have been adequately tested locally.
- [x] All automated tests are passing.
- [x] I have updated/added required automated tests.
- [x] Pre-commit checks are passing.
