### PR TITLE
feature: cpd-392 cpd-393 categorization workflow dynamic data without reload and description

### DIFF
--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
@@ -80,6 +80,11 @@ export class CategorizationSubmitComponent {
           .subscribe(
             (success) => {
               this.alertsSvc.alert('Category has been updated.');
+              const proxy = this.categoryList.data.findIndex(
+                (obj) => obj._id === categorization_id
+              );
+              this.categoryList.data.splice(proxy, 1);
+              this.categoryList.data = this.categoryList.data;
             },
             (failure) => {
               this.alertsSvc.alert('Error updating category.');

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-verify/categorization-verify.component.ts
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-verify/categorization-verify.component.ts
@@ -78,6 +78,11 @@ export class CategorizationVerifyComponent {
           .subscribe(
             (success) => {
               this.alertsSvc.alert('Proxy status has been updated.');
+              const proxy = this.categoryList.data.findIndex(
+                (obj) => obj._id === categorization_id
+              );
+              this.categoryList.data.splice(proxy, 1);
+              this.categoryList.data = this.categoryList.data;
             },
             (failure) => {
               this.alertsSvc.alert('Error updating proxy status.');

--- a/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.html
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.html
@@ -1,7 +1,22 @@
 <div class="flex flex-container tab">
   <h5>Proxy Categorization</h5>
+  <div *ngIf="categoryList.filteredData.length > 0">
+    <p>
+      A Category Manager will have this domain categorized within 24 business
+      hours.
+    </p>
+    <p>
+      However, if you'd like to have this domain categorized sooner, you can
+      categorize this domain for each proxy below.
+    </p>
+  </div>
   <div *ngIf="categoryList.filteredData.length === 0" [formGroup]="tabForm">
-    <div class="text-muted mb-3">A proxy category must be selected.</div>
+    <p>Please submit a preferred category below.</p>
+    <p>
+      Once submitted, A Category Manager will have this domain categorized
+      within 24 business hours.
+    </p>
+    <div class="text-muted mt-3 mb-3">A proxy category must be selected.</div>
     <mat-form-field style="width: 20em" appearance="outline">
       <mat-select formControlName="category_one">
         <mat-option [value]="null">--Select--</mat-option>

--- a/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.ts
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.ts
@@ -97,7 +97,6 @@ export class DomainDetailsProxyCategorizaitonComponent implements OnInit {
   checkCategory() {
     this.ddTabSvc.checkCategories().subscribe(
       (success) => {
-        console.log(success);
         if (Array.isArray(success)) {
           this.categoryData = success as Array<any>;
           this.categoryList = new MatTableDataSource<any>(success);
@@ -119,16 +118,22 @@ export class DomainDetailsProxyCategorizaitonComponent implements OnInit {
     const dialogRef = this.dialog.open(ConfirmCategoryDialogComponent, {
       data: dialogSettings,
     });
+    const status = 'submitted';
     dialogRef.afterClosed().subscribe((result) => {
       if (result.closedStatus === 'confirmed') {
         this.ddTabSvc
           .updateCategory(categorization_id, {
             category: result.selectedCategory,
-            status: 'submitted',
+            status: status,
           })
           .subscribe(
             (success) => {
               this.alertsSvc.alert('Category has been updated.');
+              const proxy = this.categoryList.data.findIndex(
+                (obj) => obj._id === categorization_id
+              );
+              this.categoryList.data[proxy].category = result.selectedCategory;
+              this.categoryList.data[proxy].status = status;
             },
             (failure) => {
               this.alertsSvc.alert('Error updating category.');

--- a/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.ts
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.ts
@@ -134,6 +134,7 @@ export class DomainDetailsProxyCategorizaitonComponent implements OnInit {
               );
               this.categoryList.data[proxy].category = result.selectedCategory;
               this.categoryList.data[proxy].status = status;
+              this.categoryList.data[proxy].updated = new Date();
             },
             (failure) => {
               this.alertsSvc.alert('Error updating category.');


### PR DESCRIPTION
Update categorization workflow data without needing to reload
Add description clarifying a category manager will have domains categorized.

## 🗣 Description ##
Update categorization workflow data without needing to reload in the proxy category tab and in the categorizations page
Add description clarifying a category manager will have domains categorized in the proxy category tab

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Test ran successfully

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - _eschew scope creep!_
- [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.
