### PR TITLE
feature: CPD-406 add categorization request email setting to about

### DIFF
--- a/src/domainManagementUI/src/app/components/about/about.component.html
+++ b/src/domainManagementUI/src/app/components/about/about.component.html
@@ -48,6 +48,17 @@
         />
       </mat-form-field>
     </div>
+    <div>
+      <mat-form-field appearance="outline">
+        <mat-label>Send Categorization Request Emails To</mat-label>
+        <input
+          matInput
+          type="test"
+          trim="blur"
+          [(ngModel)]="settingsData.CATEGORIZATION_EMAIL"
+        />
+      </mat-form-field>
+    </div>
   </mat-card-content>
   <mat-card-actions>
     <button mat-raised-button color="primary" (click)="saveSettings()">

--- a/src/domainManagementUI/src/app/models/about.model.ts
+++ b/src/domainManagementUI/src/app/models/about.model.ts
@@ -9,4 +9,5 @@ export class AboutModel extends BaseModel {
 export class SettingsModel {
   SES_FORWARD_EMAIL: string;
   USER_NOTIFICATION_EMAIL: string;
+  CATEGORIZATION_EMAIL: string;
 }


### PR DESCRIPTION
Add the ability to set the categorization request email setting to the about page

## 🗣 Description ##
Be able to set up an email to receive notifications for incoming categorization requests

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Test ran locally

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - _eschew scope creep!_
- [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.
