### PR TITLE
feature: cpd-426 categorization upgrades

### DIFF
--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
@@ -61,7 +61,7 @@
       <mat-cell *matCellDef="let row">
         <button
           mat-raised-button
-          (click)="categorize(row._id, row.categorize_url)"
+          (click)="categorize(row._id, row.categorize_url, row.category)"
           color="primary"
         >
           Categorize

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
@@ -63,9 +63,10 @@ export class CategorizationSubmitComponent {
     );
   }
 
-  categorize(categorization_id, categorize_url) {
+  categorize(categorization_id, categorize_url, preferred_category) {
     const dialogSettings = {
       categoryList: this.categories,
+      preferredCategory: preferred_category,
     };
     const dialogRef = this.dialog.open(ConfirmCategoryDialogComponent, {
       data: dialogSettings,

--- a/src/domainManagementUI/src/app/components/dialog-windows/confirm-categorize/confirm-categorize-dialog.component.html
+++ b/src/domainManagementUI/src/app/components/dialog-windows/confirm-categorize/confirm-categorize-dialog.component.html
@@ -6,7 +6,11 @@
 ></button>
 <mat-form-field [formGroup]="categorizationFormGroup" appearance="outline">
   <mat-icon matPrefix style="margin-right: 10px">category</mat-icon>
-  <mat-select formControlName="categorization_id" placeholder="Select">
+  <mat-select
+    [(ngModel)]="defaultValue"
+    formControlName="categorization_id"
+    placeholder="Select"
+  >
     <mat-option [value]="null">--Select--</mat-option>
     <mat-option *ngFor="let a of data.categoryList" [value]="a">
       {{ a }}

--- a/src/domainManagementUI/src/app/components/dialog-windows/confirm-categorize/confirm-categorize-dialog.component.ts
+++ b/src/domainManagementUI/src/app/components/dialog-windows/confirm-categorize/confirm-categorize-dialog.component.ts
@@ -18,6 +18,7 @@ export class ConfirmCategoryDialogComponent {
   functionOnConfirm: any;
   selectedCategory: string;
   categorizationFormGroup: FormGroup;
+  defaultValue: string;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: any,
@@ -27,7 +28,7 @@ export class ConfirmCategoryDialogComponent {
     this.functionOnConfirm = data.functionOnConfirm;
     this.itemConfirming = data.itemConfirming;
     this.actionConfirming = data.actionConfirming;
-
+    this.defaultValue = data.preferredCategory;
     this.categorizationFormGroup = new FormGroup({
       categorization_id: new FormControl('', [Validators.required]),
     });

--- a/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.html
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.html
@@ -105,7 +105,7 @@
         <div *ngIf="row.status === 'new'; else elseRecategorize">
           <button
             mat-raised-button
-            (click)="categorize(row._id, row.categorize_url)"
+            (click)="categorize(row._id, row.categorize_url, row.category)"
             color="primary"
           >
             Categorize
@@ -114,7 +114,7 @@
         <ng-template #elseRecategorize>
           <button
             mat-raised-button
-            (click)="categorize(row._id, row.categorize_url)"
+            (click)="categorize(row._id, row.categorize_url, row.category)"
             color="primary"
           >
             Recategorize

--- a/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.html
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.html
@@ -102,7 +102,7 @@
         >Action</mat-header-cell
       >
       <mat-cell *matCellDef="let row">
-        <div *ngIf="row.status === 'new'; else elseRecategorize">
+        <div *ngIf="row.status === 'new'; else Recheck">
           <button
             mat-raised-button
             (click)="categorize(row._id, row.categorize_url, row.category)"
@@ -111,10 +111,20 @@
             Categorize
           </button>
         </div>
-        <ng-template #elseRecategorize>
+        <ng-template #Recheck>
           <button
+            *ngIf="row.status === 'verified'; else Recategorize"
             mat-raised-button
             (click)="categorize(row._id, row.categorize_url, row.category)"
+            color="primary"
+          >
+            Recheck
+          </button>
+        </ng-template>
+        <ng-template #Recategorize>
+          <button
+            mat-raised-button
+            (click)="categorize(row._id, row.check_url, row.category)"
             color="primary"
           >
             Recategorize

--- a/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.ts
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.ts
@@ -110,9 +110,10 @@ export class DomainDetailsProxyCategorizationComponent implements OnInit {
     );
   }
 
-  categorize(categorization_id, categorize_url) {
+  categorize(categorization_id, categorize_url, preferredCategory) {
     const dialogSettings = {
       categoryList: this.categories,
+      preferredCategory: preferredCategory,
     };
     const dialogRef = this.dialog.open(ConfirmCategoryDialogComponent, {
       data: dialogSettings,

--- a/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.ts
+++ b/src/domainManagementUI/src/app/components/domain/domain-details/tabs/proxy-categorization/domain-details-proxy-categorization.component.ts
@@ -110,10 +110,10 @@ export class DomainDetailsProxyCategorizationComponent implements OnInit {
     );
   }
 
-  categorize(categorization_id, categorize_url, preferredCategory) {
+  categorize(categorization_id, categorize_url, preferred_category) {
     const dialogSettings = {
       categoryList: this.categories,
-      preferredCategory: preferredCategory,
+      preferredCategory: preferred_category,
     };
     const dialogRef = this.dialog.open(ConfirmCategoryDialogComponent, {
       data: dialogSettings,


### PR DESCRIPTION
Add recheck button for domain proxies that are verified
Add preferred category as the default category for categorization dropdowns

## 🗣 Description ##
Added recheck button so users can quickly check if the domain's category is still true

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Test ran locally

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - _eschew scope creep!_
- [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.
