### PR TITLE
feature: cpd 433 - 450 un request categorization and add email toggle to cat page

### DIFF
--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
@@ -4,76 +4,81 @@
   categorization service(s). Select the categorize button to link to the proxy
   categorization website to allow you to select a category for a domain.
 </div>
-<div>
-  <mat-table [dataSource]="categoryList" matSort>
-    <!-- Domain Name -->
-    <ng-container matColumnDef="domain">
-      <mat-header-cell *matHeaderCellDef mat-sort-header
-        >Domain</mat-header-cell
-      >
-      <mat-cell *matCellDef="let row">{{ row.domain_name }}</mat-cell>
-    </ng-container>
-
-    <!-- Proxy Name -->
-    <ng-container matColumnDef="proxy">
-      <mat-header-cell *matHeaderCellDef mat-sort-header
-        >Proxy Source</mat-header-cell
-      >
-      <mat-cell *matCellDef="let row">{{ row.proxy }}</mat-cell>
-    </ng-container>
-
-    <!-- Status -->
-    <ng-container matColumnDef="status">
-      <mat-header-cell *matHeaderCellDef mat-sort-header
-        >Status</mat-header-cell
-      >
-      <mat-cell *matCellDef="let row">{{ row.status }}</mat-cell>
-    </ng-container>
-
-    <!-- Category Name -->
-    <ng-container matColumnDef="category">
-      <mat-header-cell *matHeaderCellDef mat-sort-header
-        >Preferred Category</mat-header-cell
-      >
-      <mat-cell *matCellDef="let row">{{ row.category }}</mat-cell>
-    </ng-container>
-
-    <!-- Date Requested -->
-    <ng-container matColumnDef="updated">
-      <mat-header-cell *matHeaderCellDef mat-sort-header
-        >Date Requested</mat-header-cell
-      >
-      <mat-cell *matCellDef="let row">
-        <ng-container *ngIf="row['updated']; else elseCreated">{{
-          row.updated | date: "MM/dd/yy"
-        }}</ng-container>
-        <ng-template #elseCreated>{{
-          row.created | date: "MM/dd/yy"
-        }}</ng-template>
-      </mat-cell>
-    </ng-container>
-
-    <!-- Categorize -->
-    <ng-container matColumnDef="categorize">
-      <mat-header-cell *matHeaderCellDef mat-sort-header
-        >Categorize</mat-header-cell
-      >
-      <mat-cell *matCellDef="let row">
-        <button
-          mat-raised-button
-          (click)="categorize(row._id, row.categorize_url, row.category)"
-          color="primary"
+<div *ngFor="let domain of domainData">
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>
+      <mat-panel-title>
+        {{ domain.domain_name }}
+      </mat-panel-title>
+      <button mat-raised-button class="domain-button" color="primary">
+        Enable Email
+      </button>
+      <button mat-stroked-button class="domain-button" color="warn">
+        Reject
+      </button>
+    </mat-expansion-panel-header>
+    <mat-table [dataSource]="domain.categories" matSort>
+      <!-- Proxy Name -->
+      <ng-container matColumnDef="proxy">
+        <mat-header-cell *matHeaderCellDef mat-sort-header
+          >Proxy Source</mat-header-cell
         >
-          Categorize
-        </button>
-      </mat-cell>
-    </ng-container>
+        <mat-cell *matCellDef="let row">{{ row.proxy }}</mat-cell>
+      </ng-container>
 
-    <!-- Header Info -->
-    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-    <mat-row
-      class="table-row cursor-pointer"
-      *matRowDef="let row; columns: displayedColumns"
-    ></mat-row>
-  </mat-table>
+      <!-- Status -->
+      <ng-container matColumnDef="status">
+        <mat-header-cell *matHeaderCellDef mat-sort-header
+          >Status</mat-header-cell
+        >
+        <mat-cell *matCellDef="let row">{{ row.status }}</mat-cell>
+      </ng-container>
+
+      <!-- Category Name -->
+      <ng-container matColumnDef="category">
+        <mat-header-cell *matHeaderCellDef mat-sort-header
+          >Preferred Category</mat-header-cell
+        >
+        <mat-cell *matCellDef="let row">{{ row.category }}</mat-cell>
+      </ng-container>
+
+      <!-- Date Requested -->
+      <ng-container matColumnDef="updated">
+        <mat-header-cell *matHeaderCellDef mat-sort-header
+          >Date Requested</mat-header-cell
+        >
+        <mat-cell *matCellDef="let row">
+          <ng-container *ngIf="row['updated']; else elseCreated">{{
+            row.updated | date: "MM/dd/yy"
+          }}</ng-container>
+          <ng-template #elseCreated>{{
+            row.created | date: "MM/dd/yy"
+          }}</ng-template>
+        </mat-cell>
+      </ng-container>
+
+      <!-- Categorize -->
+      <ng-container matColumnDef="categorize">
+        <mat-header-cell *matHeaderCellDef mat-sort-header
+          >Categorize</mat-header-cell
+        >
+        <mat-cell *matCellDef="let row">
+          <button
+            mat-raised-button
+            (click)="categorize(row._id, row.categorize_url, row.category)"
+            color="primary"
+          >
+            Categorize
+          </button>
+        </mat-cell>
+      </ng-container>
+
+      <!-- Header Info -->
+      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+      <mat-row
+        class="table-row cursor-pointer"
+        *matRowDef="let row; columns: displayedColumns"
+      ></mat-row>
+    </mat-table>
+  </mat-expansion-panel>
 </div>

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
@@ -10,7 +10,12 @@
       <mat-panel-title>
         {{ domain.domain_name }}
       </mat-panel-title>
-      <button mat-raised-button class="domain-button" color="primary">
+      <button
+        mat-raised-button
+        class="domain-button"
+        color="primary"
+        (click)="toggleEmail(domain.domain_id)"
+      >
         Enable Email
       </button>
       <button

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
@@ -19,6 +19,7 @@
         Enable Email
       </button>
       <button
+        *ngIf="canReject(domain.categories.data)"
         mat-stroked-button
         class="domain-button"
         color="warn"

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
@@ -11,6 +11,7 @@
         {{ domain.domain_name }}
       </mat-panel-title>
       <button
+        *ngIf="!domain.email_active"
         mat-raised-button
         class="domain-button"
         color="primary"

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
@@ -13,7 +13,12 @@
       <button mat-raised-button class="domain-button" color="primary">
         Enable Email
       </button>
-      <button mat-stroked-button class="domain-button" color="warn">
+      <button
+        mat-stroked-button
+        class="domain-button"
+        color="warn"
+        (click)="reject(domain.domain_id)"
+      >
         Reject
       </button>
     </mat-expansion-panel-header>

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.scss
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.scss
@@ -1,3 +1,8 @@
+mat-panel-title {
+  font-weight: bold;
+  margin-top: 5px;
+}
+
 .domain-button {
   margin-right: 20px;
 }

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.scss
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.scss
@@ -1,0 +1,3 @@
+.domain-button {
+  margin-right: 20px;
+}

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
@@ -10,6 +10,8 @@ import { CategoryService } from 'src/app/services/category.service';
 import { ConfirmCategoryDialogComponent } from 'src/app/components/dialog-windows/confirm-categorize/confirm-categorize-dialog.component';
 import { LayoutService } from 'src/app/services/layout.service';
 import { CategorizationTabService } from 'src/app/services/tab-services/categorization-tabs.service';
+import { ConfirmDialogComponent } from 'src/app/components/dialog-windows/confirm/confirm-dialog.component';
+import { ConfirmDialogSettings } from 'src/app/models/confirmDialogSettings.model';
 
 @Component({
   selector: 'app-categorization-submit',
@@ -102,5 +104,33 @@ export class CategorizationSubmitComponent {
       }
     });
     window.open(categorize_url, '_blank');
+  }
+
+  reject(domain_id) {
+    const dialogSettings = new ConfirmDialogSettings();
+    dialogSettings.itemConfirming = 'Confirm Proxy Requests Delete';
+    dialogSettings.actionConfirming = `Are you sure you want to delete all proxies for this domain?`;
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: dialogSettings,
+    });
+
+    dialogRef.afterClosed().subscribe((result) => {
+      this.categorizationTabSvc.deleteProxies(domain_id).subscribe(
+        (success) => {
+          this.alertsSvc.alert(
+            'Proxy requests for this domain have been deleted.'
+          );
+          const proxies = this.domainData.findIndex(
+            (obj) => obj.domain_id === domain_id
+          );
+          this.domainData.splice(proxies, 1);
+          this.domainData = this.domainData;
+        },
+        (failure) => {
+          console.log(failure);
+          this.alertsSvc.alert(`${failure.error.error}`);
+        }
+      );
+    });
   }
 }

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
@@ -115,22 +115,53 @@ export class CategorizationSubmitComponent {
     });
 
     dialogRef.afterClosed().subscribe((result) => {
-      this.categorizationTabSvc.deleteProxies(domain_id).subscribe(
-        (success) => {
-          this.alertsSvc.alert(
-            'Proxy requests for this domain have been deleted.'
-          );
-          const proxies = this.domainData.findIndex(
-            (obj) => obj.domain_id === domain_id
-          );
-          this.domainData.splice(proxies, 1);
-          this.domainData = this.domainData;
-        },
-        (failure) => {
-          console.log(failure);
-          this.alertsSvc.alert(`${failure.error.error}`);
-        }
-      );
+      if (result === 'confirmed') {
+        this.categorizationTabSvc.deleteProxies(domain_id).subscribe(
+          (success) => {
+            this.alertsSvc.alert(
+              'Proxy requests for this domain have been deleted.'
+            );
+            const proxies = this.domainData.findIndex(
+              (obj) => obj.domain_id === domain_id
+            );
+            this.domainData.splice(proxies, 1);
+            this.domainData = this.domainData;
+          },
+          (failure) => {
+            console.log(failure);
+            this.alertsSvc.alert(`${failure.error.error}`);
+          }
+        );
+      } else {
+        dialogRef.close();
+      }
+    });
+  }
+
+  toggleEmail(domain_id) {
+    const dialogSettings = new ConfirmDialogSettings();
+    dialogSettings.itemConfirming = 'Enable Email Receiving';
+    dialogSettings.actionConfirming = `Are you sure you want to receive emails to this domain?`;
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: dialogSettings,
+    });
+
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result === 'confirmed') {
+        this.categorizationTabSvc.enableEmailReceiving(domain_id).subscribe(
+          (success) => {
+            this.alertsSvc.alert(
+              'Email receiving for this domain has been enabled.'
+            );
+          },
+          (failure) => {
+            console.log(failure);
+            this.alertsSvc.alert(`${failure.error.error}`);
+          }
+        );
+      } else {
+        dialogRef.close();
+      }
     });
   }
 }

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
@@ -73,6 +73,10 @@ export class CategorizationSubmitComponent {
     );
   }
 
+  canReject(categories) {
+    return categories.length === 8;
+  }
+
   categorize(categorization_id, categorize_url, preferred_category) {
     const dialogSettings = {
       categoryList: this.categories,

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
@@ -18,14 +18,8 @@ import { CategorizationTabService } from 'src/app/services/tab-services/categori
 })
 export class CategorizationSubmitComponent {
   categoryData = [];
-  displayedColumns = [
-    'domain',
-    'proxy',
-    'status',
-    'category',
-    'updated',
-    'categorize',
-  ];
+  domainData = [];
+  displayedColumns = ['proxy', 'status', 'category', 'updated', 'categorize'];
   categoryList: MatTableDataSource<any> = new MatTableDataSource<any>();
 
   @ViewChild(MatSort) sort: MatSort;
@@ -51,8 +45,22 @@ export class CategorizationSubmitComponent {
       (success) => {
         if (Array.isArray(success)) {
           this.categoryData = success as Array<any>;
-          this.categoryList = new MatTableDataSource<any>(success);
-          this.categoryList.sort = this.sort;
+          this.categoryData.forEach((i) => {
+            let found = this.domainData.some(
+              (el) => el.domain_name === i.domain_name
+            );
+            if (!found) {
+              this.domainData.push({
+                domain_name: i.domain_name,
+                domain_id: i.domain_id,
+                categories: new MatTableDataSource<any>(
+                  this.categoryData.filter(
+                    (x) => x.domain_name == i.domain_name
+                  )
+                ),
+              });
+            }
+          });
         } else {
           this.alertsSvc.alert('No domains for proxy submission.');
         }

--- a/src/domainManagementUI/src/app/services/category.service.ts
+++ b/src/domainManagementUI/src/app/services/category.service.ts
@@ -57,4 +57,9 @@ export class CategoryService {
     const url = `${this.settingsService.settings.apiUrl}/api/categorization/${id}/`;
     return this.http.put(url, data);
   }
+
+  deleteProxyRequests(domainId: string) {
+    const url = `${this.settingsService.settings.apiUrl}/api/domain/${domainId}/categorize/`;
+    return this.http.delete(url);
+  }
 }

--- a/src/domainManagementUI/src/app/services/category.service.ts
+++ b/src/domainManagementUI/src/app/services/category.service.ts
@@ -38,6 +38,11 @@ export class CategoryService {
     return this.http.get(url);
   }
 
+  domainDetails(domainId: string) {
+    const url = `${this.settingsService.settings.apiUrl}/api/domain/${domainId}`;
+    return this.http.get(url);
+  }
+
   submitCategory(domainId: string, categoryName: string) {
     const url = `${this.settingsService.settings.apiUrl}/api/domain/${domainId}/categorize/`;
     return this.http.post(url, { category: categoryName });

--- a/src/domainManagementUI/src/app/services/tab-services/categorization-tabs.service.ts
+++ b/src/domainManagementUI/src/app/services/tab-services/categorization-tabs.service.ts
@@ -5,6 +5,7 @@ import { Injectable, OnInit } from '@angular/core';
 // Local Servie Imports
 import { AlertsService } from 'src/app/services/alerts.service';
 import { CategoryService } from 'src/app/services/category.service';
+import { EmailService } from '../email.service';
 import { UserAuthService } from 'src/app/services/user-auth.service';
 
 // Models
@@ -27,6 +28,7 @@ export class CategorizationTabService {
 
   constructor(
     public alertsSvc: AlertsService,
+    public emailSvc: EmailService,
     public categorySvc: CategoryService,
     private userAuthSvc: UserAuthService
   ) {
@@ -43,5 +45,9 @@ export class CategorizationTabService {
 
   deleteProxies(domainId: string) {
     return this.categorySvc.deleteProxyRequests(domainId);
+  }
+
+  enableEmailReceiving(domainId: string) {
+    return this.emailSvc.setDomainEmailsStatus(domainId, true);
   }
 }

--- a/src/domainManagementUI/src/app/services/tab-services/categorization-tabs.service.ts
+++ b/src/domainManagementUI/src/app/services/tab-services/categorization-tabs.service.ts
@@ -5,6 +5,7 @@ import { Injectable, OnInit } from '@angular/core';
 // Local Servie Imports
 import { AlertsService } from 'src/app/services/alerts.service';
 import { CategoryService } from 'src/app/services/category.service';
+import { DomainService } from '../domain.service';
 import { EmailService } from '../email.service';
 import { UserAuthService } from 'src/app/services/user-auth.service';
 
@@ -28,6 +29,7 @@ export class CategorizationTabService {
 
   constructor(
     public alertsSvc: AlertsService,
+    public domainSvc: DomainService,
     public emailSvc: EmailService,
     public categorySvc: CategoryService,
     private userAuthSvc: UserAuthService
@@ -37,6 +39,10 @@ export class CategorizationTabService {
 
   getCategorizations(status) {
     return this.categorySvc.getCategorizations(status);
+  }
+
+  domainDetails(domainId: string) {
+    return this.categorySvc.domainDetails(domainId);
   }
 
   updateCategory(id: string, data: object) {

--- a/src/domainManagementUI/src/app/services/tab-services/categorization-tabs.service.ts
+++ b/src/domainManagementUI/src/app/services/tab-services/categorization-tabs.service.ts
@@ -40,4 +40,8 @@ export class CategorizationTabService {
   updateCategory(id: string, data: object) {
     return this.categorySvc.updateCategorization(id, data);
   }
+
+  deleteProxies(domainId: string) {
+    return this.categorySvc.deleteProxyRequests(domainId);
+  }
 }


### PR DESCRIPTION
Refactor categorization page to include additional functionalities

## 🗣 Description ##
Each row in the proxy tab of the categorization page are now domains and user can access its proxies by expanding the expansion panel.
This allows to add the ability to remove category requests button  and enable email receiving at the domain level and not the proxy level

## 💭 Motivation and context ##
Increase efficiency for the categorization manager's workflow

## 🧪 Testing ##
test ran locally

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - _eschew scope creep!_
- [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.
