### PR TITLE
feature: cpd-618 and cpd-595 categorization add link and name

### DIFF
--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
@@ -8,7 +8,9 @@
   <mat-expansion-panel>
     <mat-expansion-panel-header>
       <mat-panel-title>
-        {{ domain.domain_name }}
+        <a class="primary" href="domain/details/{{ domain.domain_id }}">{{
+          domain.domain_name
+        }}</a>
       </mat-panel-title>
       <mat-icon
         *ngIf="domain.is_active"

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
@@ -84,7 +84,8 @@
                 row._id,
                 row.categorize_url,
                 row.category,
-                domain.domain_id
+                domain.domain_id,
+                domain.domain_name
               )
             "
             color="primary"

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.scss
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.scss
@@ -11,3 +11,7 @@ mat-panel-title {
   margin-top: 3px;
   margin-right: 20px;
 }
+
+a {
+  color: inherit;
+}

--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.ts
@@ -137,8 +137,15 @@ export class CategorizationSubmitComponent extends CategorizationComponent {
     );
   }
 
-  categorize(categorization_id, categorize_url, preferred_category, domain_id) {
+  categorize(
+    categorization_id,
+    categorize_url,
+    preferred_category,
+    domain_id,
+    domain_name
+  ) {
     const dialogSettings = {
+      domainName: domain_name,
       categoryList: this.categories,
       preferredCategory: preferred_category,
     };

--- a/src/domainManagementUI/src/app/components/dialog-windows/confirm-categorize/confirm-categorize-dialog.component.html
+++ b/src/domainManagementUI/src/app/components/dialog-windows/confirm-categorize/confirm-categorize-dialog.component.html
@@ -1,4 +1,4 @@
-<h2 mat-dialog-title>{{ itemConfirming | titlecase }}</h2>
+<h2 mat-dialog-title>{{ data.domainName }}</h2>
 <button
   mat-button
   style="display: inline-block; float: right; top: -4em; margin-bottom: -4em"


### PR DESCRIPTION
Add domain name to confirm category and link to confirm tab

## 🗣 Description ##
improve workflow efficiency for categorization manager by having quick access to the domain details page when needed.

have domain name in pop up for quick reference when categorization domains

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
tested locally

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
