### PR TITLE
fix: cpd-650 external domain link

### DIFF
--- a/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
+++ b/src/domainManagementUI/src/app/components/categorization/tabs/categorization-submit/categorization-submit.component.html
@@ -8,9 +8,18 @@
   <mat-expansion-panel>
     <mat-expansion-panel-header>
       <mat-panel-title>
-        <a class="primary" href="domain/details/{{ domain.domain_id }}">{{
-          domain.domain_name
-        }}</a>
+        <a
+          *ngIf="domain.is_external; else notExternal"
+          class="primary"
+          href="//{{ domain.domain_name }}"
+          target="_blank"
+          >{{ domain.domain_name }}</a
+        >
+        <ng-template #notExternal>
+          <a class="primary" href="domain/details/{{ domain.domain_id }}">{{
+            domain.domain_name
+          }}</a>
+        </ng-template>
       </mat-panel-title>
       <mat-icon
         *ngIf="domain.is_active"


### PR DESCRIPTION
fix external domain link in the categorization page

## 🗣 Description ##
domain links redirect the categorization manager to the domain details page. however external domains
are not managed by domain manager therefore does not have a domain details page.
instead this fix allows the user to redirect to check the actual domain website in a new tab

## 💭 Motivation and context ##
bug fix

## 🧪 Testing ##
tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
